### PR TITLE
feat: stat date range filter for leaderboard and reports

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -75,15 +75,13 @@
       "title": "Leaderboard",
       "footerText": "Top 5 users by total hours clocked-in.",
       "viewMore": "View Full Leaderboard",
-      "clearFilter": "Clear",
       "showingRange": "Showing: {start} - {end}",
       "viewMoreDialog": {
         "title": "Full Leaderboard"
       }
     },
     "leaderboardWithFilter": {
-      "title": "Leaderboard",
-      "clearFilter": "Clear"
+      "title": "Leaderboard"
     },
     "tabs": {
       "home": "Home",
@@ -184,7 +182,7 @@
   },
   "StatRangeSelector": {
     "label": "Stat Range",
-    "placeholder": "Select a stat range",
+    "all": "All",
     "loading": "Loading..."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -75,9 +75,15 @@
       "title": "Leaderboard",
       "footerText": "Top 5 users by total hours clocked-in.",
       "viewMore": "View Full Leaderboard",
+      "clearFilter": "Clear",
+      "showingRange": "Showing: {start} - {end}",
       "viewMoreDialog": {
         "title": "Full Leaderboard"
       }
+    },
+    "leaderboardWithFilter": {
+      "title": "Leaderboard",
+      "clearFilter": "Clear"
     },
     "tabs": {
       "home": "Home",
@@ -155,6 +161,7 @@
       "logs": "Logs",
       "reports": "Reports",
       "users": "Users",
+      "statRanges": "Stat Ranges",
       "signIn": "Sign-In",
       "signOut": "Sign-Out"
     },
@@ -174,5 +181,10 @@
   },
   "LastUpdatedText": {
     "lastUpdated": "Last updated {timeString}"
+  },
+  "StatRangeSelector": {
+    "label": "Stat Range",
+    "placeholder": "Select a stat range",
+    "loading": "Loading..."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -182,7 +182,6 @@
   },
   "StatRangeSelector": {
     "label": "Stat Range",
-    "all": "All",
-    "loading": "Loading..."
+    "all": "All"
   }
 }

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -75,15 +75,13 @@
       "title": "排行榜",
       "footerText": "按總簽到時數排名的前 5 名使用者。",
       "viewMore": "查看完整排行榜",
-      "clearFilter": "清除",
       "showingRange": "顯示：{start} - {end}",
       "viewMoreDialog": {
         "title": "完整排行榜"
       }
     },
     "leaderboardWithFilter": {
-      "title": "排行榜",
-      "clearFilter": "清除"
+      "title": "排行榜"
     },
     "tabs": {
       "home": "主畫面",
@@ -184,7 +182,7 @@
   },
   "StatRangeSelector": {
     "label": "統計範圍",
-    "placeholder": "選擇統計範圍",
+    "all": "全部",
     "loading": "載入中..."
   }
 }

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -75,9 +75,15 @@
       "title": "排行榜",
       "footerText": "按總簽到時數排名的前 5 名使用者。",
       "viewMore": "查看完整排行榜",
+      "clearFilter": "清除",
+      "showingRange": "顯示：{start} - {end}",
       "viewMoreDialog": {
         "title": "完整排行榜"
       }
+    },
+    "leaderboardWithFilter": {
+      "title": "排行榜",
+      "clearFilter": "清除"
     },
     "tabs": {
       "home": "主畫面",
@@ -155,6 +161,7 @@
       "logs": "紀錄",
       "reports": "報告",
       "users": "使用者",
+      "statRanges": "統計範圍",
       "signIn": "登入",
       "signOut": "登出"
     },
@@ -174,5 +181,10 @@
   },
   "LastUpdatedText": {
     "lastUpdated": "最後更新 {timeString}"
+  },
+  "StatRangeSelector": {
+    "label": "統計範圍",
+    "placeholder": "選擇統計範圍",
+    "loading": "載入中..."
   }
 }

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -182,7 +182,6 @@
   },
   "StatRangeSelector": {
     "label": "統計範圍",
-    "all": "全部",
-    "loading": "載入中..."
+    "all": "全部"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,3 +53,19 @@ model Team {
   users   User[]   @relation(fields: [userIds], references: [id])
   userIds String[] @default([]) @db.ObjectId
 }
+
+enum StatRangeStatus {
+  Active
+  Archived
+}
+
+model StatRange {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  name      String
+  startDate DateTime
+  endDate   DateTime
+  status    StatRangeStatus @default(Active)
+}

--- a/src/app/_components/LeaderboardCard.tsx
+++ b/src/app/_components/LeaderboardCard.tsx
@@ -1,0 +1,117 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Button, Card, CloseButton, Dialog, HStack, Icon, Portal, Text, VStack, Spinner, Center
+} from "@chakra-ui/react";
+import { LuChevronsRight } from "react-icons/lu";
+
+import LeaderboardTable from "@/components/LeaderboardTable";
+import StatRangeSelector from "@/components/StatRangeSelector";
+import { getLeaderboardRankings } from "../actions";
+
+export default function LeaderboardCard(props: {
+  initialRankings: { id: string; name: string; duration: number }[];
+}) {
+  const { initialRankings } = props;
+  const t = useTranslations("HomePage.leaderboardCard");
+
+  const [rankings, setRankings] = useState(initialRankings);
+  const [loading, setLoading] = useState(false);
+  const [selectedRange, setSelectedRange] = useState<{ startDate: Date; endDate: Date } | null>(null);
+  const [selectorKey, setSelectorKey] = useState(0);
+
+  const handleStatRangeSelect = async (startDate: Date, endDate: Date) => {
+    setSelectedRange({ startDate, endDate });
+    setLoading(true);
+    try {
+      const newRankings = await getLeaderboardRankings({ startDate, endDate });
+      setRankings(newRankings);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClearRange = async () => {
+    setSelectedRange(null);
+    setSelectorKey(k => k + 1);
+    setLoading(true);
+    try {
+      const newRankings = await getLeaderboardRankings();
+      setRankings(newRankings);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog.Root>
+      <Card.Root w="full" size="sm">
+        <Card.Header>
+          <HStack justify="space-between" w="full">
+            <Card.Title>{t("title")}</Card.Title>
+            <HStack gap={2}>
+              <StatRangeSelector key={selectorKey} onSelectAction={handleStatRangeSelect} />
+              {selectedRange && (
+                <Button size="xs" variant="ghost" onClick={handleClearRange}>
+                  {t("clearFilter")}
+                </Button>
+              )}
+            </HStack>
+          </HStack>
+        </Card.Header>
+        <Card.Body>
+          {loading ? (
+            <Center py={4}>
+              <Spinner size="md" />
+            </Center>
+          ) : (
+            <LeaderboardTable rankings={rankings} limits={5} />
+          )}
+        </Card.Body>
+        <Card.Footer>
+          <Text fontSize="sm" color="gray.500">{t("footerText")}</Text>
+          <Dialog.Trigger asChild>
+            <Button size="xs" mt={2}>
+              {t("viewMore")}
+              <Icon><LuChevronsRight /></Icon>
+            </Button>
+          </Dialog.Trigger>
+        </Card.Footer>
+      </Card.Root>
+
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>{t("viewMoreDialog.title")}</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              {selectedRange && (
+                <HStack mb={4} gap={2}>
+                  <Text fontSize="sm" color="gray.500">
+                    {t("showingRange", {
+                      start: selectedRange.startDate.toLocaleDateString(),
+                      end: selectedRange.endDate.toLocaleDateString(),
+                    })}
+                  </Text>
+                </HStack>
+              )}
+              {loading ? (
+                <Center py={8}>
+                  <Spinner size="lg" />
+                </Center>
+              ) : (
+                <LeaderboardTable rankings={rankings} />
+              )}
+            </Dialog.Body>
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/_components/LeaderboardCard.tsx
+++ b/src/app/_components/LeaderboardCard.tsx
@@ -19,7 +19,6 @@ export default function LeaderboardCard(props: {
   const [rankings, setRankings] = useState(initialRankings);
   const [loading, setLoading] = useState(false);
   const [selectedRange, setSelectedRange] = useState<{ startDate: Date; endDate: Date } | null>(null);
-  const [selectorKey, setSelectorKey] = useState(0);
 
   const handleStatRangeSelect = async (startDate: Date, endDate: Date) => {
     setSelectedRange({ startDate, endDate });
@@ -34,7 +33,6 @@ export default function LeaderboardCard(props: {
 
   const handleClearRange = async () => {
     setSelectedRange(null);
-    setSelectorKey(k => k + 1);
     setLoading(true);
     try {
       const newRankings = await getLeaderboardRankings();
@@ -50,14 +48,10 @@ export default function LeaderboardCard(props: {
         <Card.Header>
           <HStack justify="space-between" w="full">
             <Card.Title>{t("title")}</Card.Title>
-            <HStack gap={2}>
-              <StatRangeSelector key={selectorKey} onSelectAction={handleStatRangeSelect} />
-              {selectedRange && (
-                <Button size="xs" variant="ghost" onClick={handleClearRange}>
-                  {t("clearFilter")}
-                </Button>
-              )}
-            </HStack>
+            <StatRangeSelector
+              onSelectAction={handleStatRangeSelect}
+              onClearAction={handleClearRange}
+            />
           </HStack>
         </Card.Header>
         <Card.Body>

--- a/src/app/_components/LeaderboardCard.tsx
+++ b/src/app/_components/LeaderboardCard.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import {
-  Button, Card, CloseButton, Dialog, HStack, Icon, Portal, Text, VStack, Spinner, Center
+  Button, Card, CloseButton, Dialog, HStack, Icon, Portal, Text, Spinner, Center
 } from "@chakra-ui/react";
 import { LuChevronsRight } from "react-icons/lu";
 

--- a/src/app/_components/LeaderboardWithFilter.tsx
+++ b/src/app/_components/LeaderboardWithFilter.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { Button, HStack, VStack, Spinner, Center, Heading, Popover, IconButton, Icon, Portal } from "@chakra-ui/react";
+import { HStack, VStack, Spinner, Center, Heading, Popover, IconButton, Icon, Portal } from "@chakra-ui/react";
 import { LuCalendarRange } from "react-icons/lu";
 
 import LeaderboardTable from "@/components/LeaderboardTable";
@@ -16,12 +16,9 @@ export default function LeaderboardWithFilter(props: {
 
   const [rankings, setRankings] = useState(initialRankings);
   const [loading, setLoading] = useState(false);
-  const [selectedRange, setSelectedRange] = useState<{ startDate: Date; endDate: Date } | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [selectorKey, setSelectorKey] = useState(0);
 
   const handleStatRangeSelect = async (startDate: Date, endDate: Date) => {
-    setSelectedRange({ startDate, endDate });
     setPopoverOpen(false);
     setLoading(true);
     try {
@@ -33,8 +30,7 @@ export default function LeaderboardWithFilter(props: {
   };
 
   const handleClearRange = async () => {
-    setSelectedRange(null);
-    setSelectorKey(k => k + 1);
+    setPopoverOpen(false);
     setLoading(true);
     try {
       const newRankings = await getLeaderboardRankings();
@@ -48,30 +44,26 @@ export default function LeaderboardWithFilter(props: {
     <VStack align="stretch" gap={3}>
       <HStack justify="space-between" align="center">
         <Heading as="h3" size="lg">{t("title")}</Heading>
-        <HStack gap={2}>
-          <Popover.Root open={popoverOpen} onOpenChange={(e) => setPopoverOpen(e.open)}>
-            <Popover.Trigger asChild>
-              <IconButton size="sm" variant="ghost" aria-label="Select date range">
-                <Icon><LuCalendarRange /></Icon>
-              </IconButton>
-            </Popover.Trigger>
-            <Portal>
-              <Popover.Positioner>
-                <Popover.Content>
-                  <Popover.Arrow />
-                  <Popover.Body>
-                    <StatRangeSelector key={selectorKey} onSelectAction={handleStatRangeSelect} />
-                  </Popover.Body>
-                </Popover.Content>
-              </Popover.Positioner>
-            </Portal>
-          </Popover.Root>
-          {selectedRange && (
-            <Button size="xs" variant="ghost" onClick={handleClearRange}>
-              {t("clearFilter")}
-            </Button>
-          )}
-        </HStack>
+        <Popover.Root open={popoverOpen} onOpenChange={(e) => setPopoverOpen(e.open)}>
+          <Popover.Trigger asChild>
+            <IconButton size="sm" variant="ghost" aria-label="Select date range">
+              <Icon><LuCalendarRange /></Icon>
+            </IconButton>
+          </Popover.Trigger>
+          <Portal>
+            <Popover.Positioner>
+              <Popover.Content>
+                <Popover.Arrow />
+                <Popover.Body>
+                  <StatRangeSelector
+                    onSelectAction={handleStatRangeSelect}
+                    onClearAction={handleClearRange}
+                  />
+                </Popover.Body>
+              </Popover.Content>
+            </Popover.Positioner>
+          </Portal>
+        </Popover.Root>
       </HStack>
       {loading ? (
         <Center py={8}>

--- a/src/app/_components/LeaderboardWithFilter.tsx
+++ b/src/app/_components/LeaderboardWithFilter.tsx
@@ -1,0 +1,85 @@
+"use client";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button, HStack, VStack, Spinner, Center, Heading, Popover, IconButton, Icon, Portal } from "@chakra-ui/react";
+import { LuCalendarRange } from "react-icons/lu";
+
+import LeaderboardTable from "@/components/LeaderboardTable";
+import StatRangeSelector from "@/components/StatRangeSelector";
+import { getLeaderboardRankings } from "../actions";
+
+export default function LeaderboardWithFilter(props: {
+  initialRankings: { id: string; name: string; duration: number }[];
+}) {
+  const { initialRankings } = props;
+  const t = useTranslations("HomePage.leaderboardWithFilter");
+
+  const [rankings, setRankings] = useState(initialRankings);
+  const [loading, setLoading] = useState(false);
+  const [selectedRange, setSelectedRange] = useState<{ startDate: Date; endDate: Date } | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [selectorKey, setSelectorKey] = useState(0);
+
+  const handleStatRangeSelect = async (startDate: Date, endDate: Date) => {
+    setSelectedRange({ startDate, endDate });
+    setPopoverOpen(false);
+    setLoading(true);
+    try {
+      const newRankings = await getLeaderboardRankings({ startDate, endDate });
+      setRankings(newRankings);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClearRange = async () => {
+    setSelectedRange(null);
+    setSelectorKey(k => k + 1);
+    setLoading(true);
+    try {
+      const newRankings = await getLeaderboardRankings();
+      setRankings(newRankings);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <VStack align="stretch" gap={3}>
+      <HStack justify="space-between" align="center">
+        <Heading as="h3" size="lg">{t("title")}</Heading>
+        <HStack gap={2}>
+          <Popover.Root open={popoverOpen} onOpenChange={(e) => setPopoverOpen(e.open)}>
+            <Popover.Trigger asChild>
+              <IconButton size="sm" variant="ghost" aria-label="Select date range">
+                <Icon><LuCalendarRange /></Icon>
+              </IconButton>
+            </Popover.Trigger>
+            <Portal>
+              <Popover.Positioner>
+                <Popover.Content>
+                  <Popover.Arrow />
+                  <Popover.Body>
+                    <StatRangeSelector key={selectorKey} onSelectAction={handleStatRangeSelect} />
+                  </Popover.Body>
+                </Popover.Content>
+              </Popover.Positioner>
+            </Portal>
+          </Popover.Root>
+          {selectedRange && (
+            <Button size="xs" variant="ghost" onClick={handleClearRange}>
+              {t("clearFilter")}
+            </Button>
+          )}
+        </HStack>
+      </HStack>
+      {loading ? (
+        <Center py={8}>
+          <Spinner size="lg" />
+        </Center>
+      ) : (
+        <LeaderboardTable rankings={rankings} />
+      )}
+    </VStack>
+  );
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,8 @@
 "use server";
 import { revalidatePath } from "next/cache";
 
-import { AlreadyClockedInError, clockIn, clockOut, NotClockedInError, TimeLogTooShortError } from "@/lib/data/timelog-dto";
+import { AlreadyClockedInError, clockIn, clockOut, NotClockedInError, TimeLogTooShortError, getAllUsersTotalTimeSec } from "@/lib/data/timelog-dto";
+import { getAllUserNames } from "@/lib/data/user-dto";
 
 export async function handleAdminClockIn(userId: string) {
   await clockIn(userId);
@@ -47,4 +48,23 @@ export async function userClockToggle(userId: string, isClockedIn: boolean): Pro
   } finally {
     revalidatePath("/");
   }
+}
+
+export async function getLeaderboardRankings(opts?: {
+  startDate?: Date;
+  endDate?: Date;
+}): Promise<{ id: string; name: string; duration: number }[]> {
+  // Get All User Names
+  const allUserNames = await getAllUserNames();
+  const userNameMap = Object.fromEntries(allUserNames.map(user => [user.id, user.name]));
+
+  // Get All Users Total Time with optional date range
+  const allUsersTotalTimeSec = await getAllUsersTotalTimeSec(opts);
+  
+  // Create rankings sorted by duration
+  const rankings = Object.entries(allUsersTotalTimeSec)
+    .sort((a, b) => b[1] - a[1])
+    .map(([id, duration]) => ({ id, name: userNameMap[id], duration }));
+
+  return rankings;
 }

--- a/src/app/admin/stat-ranges/StatRangesTable.tsx
+++ b/src/app/admin/stat-ranges/StatRangesTable.tsx
@@ -1,0 +1,194 @@
+"use client";
+import Link from "next/link";
+
+import { Button, ButtonGroup, Icon, IconButton, CloseButton, Dialog, Portal, Text, HStack, Badge } from "@chakra-ui/react";
+import { LuArrowDown01, LuArrowDownAZ, LuArrowUp10, LuArrowUpZA, LuPen, LuTrash2, LuPlus } from "react-icons/lu";
+
+import GenericTable, { Column } from "@/components/GenericTable";
+import { StatRangeDTO } from "@/lib/data/statrange-dto";
+import { handleDeleteStatRanges } from "./actions";
+
+type TableData = StatRangeDTO & {};
+
+const columns: Column<TableData>[] = [
+  {
+    dataKey: "name",
+    sortable: true,
+    renderHeader: (sort) => <>
+      Name
+      {sort && (
+        sort === 1 ? <Icon ml={1}><LuArrowDownAZ /></Icon>
+          : <Icon ml={1}><LuArrowUpZA /></Icon>
+      )}
+    </>,
+    renderCell: (row) => row.name,
+  },
+  {
+    dataKey: "startDate",
+    sortable: true,
+    renderHeader: (sort) => <>
+      Start Date
+      {sort && (
+        sort === 1 ? <Icon ml={1}><LuArrowDown01 /></Icon>
+          : <Icon ml={1}><LuArrowUp10 /></Icon>
+      )}
+    </>,
+    renderCell: (row) => row.startDate.toLocaleDateString(),
+  },
+  {
+    dataKey: "endDate",
+    sortable: true,
+    renderHeader: (sort) => <>
+      End Date
+      {sort && (
+        sort === 1 ? <Icon ml={1}><LuArrowDown01 /></Icon>
+          : <Icon ml={1}><LuArrowUp10 /></Icon>
+      )}
+    </>,
+    renderCell: (row) => row.endDate.toLocaleDateString(),
+  },
+  {
+    dataKey: "status",
+    sortable: true,
+    renderHeader: (sort) => <>
+      Status
+      {sort && (
+        sort === 1 ? <Icon ml={1}><LuArrowDownAZ /></Icon>
+          : <Icon ml={1}><LuArrowUpZA /></Icon>
+      )}
+    </>,
+    renderCell: (row) => (
+      <Badge colorPalette={row.status === "ACTIVE" ? "green" : "gray"}>
+        {row.status}
+      </Badge>
+    ),
+  },
+  {
+    dataKey: "createdAt",
+    sortable: true,
+    renderHeader: (sort) => <>
+      Created At
+      {sort && (
+        sort === 1 ? <Icon ml={1}><LuArrowDown01 /></Icon>
+          : <Icon ml={1}><LuArrowUp10 /></Icon>
+      )}
+    </>,
+    renderCell: (row) => row.createdAt.toLocaleString(),
+  },
+  {
+    dataKey: "actions",
+    renderHeader: () => "Actions",
+    renderCell: (row) => (
+      <ButtonGroup size="xs" variant="ghost">
+        {/* Edit Button */}
+        <IconButton asChild><Link href={`/admin/stat-ranges/${row.id}`}>
+          <Icon><LuPen /></Icon>
+        </Link></IconButton>
+
+        {/* Delete Button */}
+        <IconButton colorPalette="red" asChild><Link href={`/admin/stat-ranges/${row.id}/delete`}>
+          <Icon><LuTrash2 /></Icon>
+        </Link></IconButton>
+      </ButtonGroup>
+    ),
+  }
+];
+
+const sortingFn = (a: TableData, b: TableData, sortBy: [string, 1 | -1]) => {
+  if (!sortBy) return 0;
+  const [key, order] = sortBy;
+
+  if (key === "name" || key === "status") {
+    return (a[key].localeCompare(b[key]) * order);
+  }
+
+  if (key === "startDate" || key === "endDate" || key === "createdAt" || key === "updatedAt") {
+    return (a[key].getTime() - b[key].getTime()) * order;
+  }
+
+  return 0;
+}
+
+export default function StatRangesTable(props: {
+  statRanges: StatRangeDTO[];
+}) {
+  const { statRanges } = props;
+
+  const items: TableData[] = statRanges.map(statRange => ({
+    ...statRange,
+  }));
+
+  const topRightElement = (<HStack justify="flex-end" w="full">
+    <Button size="sm" variant="ghost" asChild>
+      <Link href="/admin/stat-ranges/new">
+        <Icon><LuPlus /></Icon>
+        Create Stat Range
+      </Link>
+    </Button>
+  </HStack>);
+
+  return <GenericTable<TableData>
+    columns={columns}
+    items={items}
+    keyFn={(item) => item.id}
+    sortingFn={sortingFn}
+    checkboxOptions={{
+      show: true,
+      showActionBar: true,
+      renderActionBarContent: (selection: string[]) => (<>
+        <Dialog.Root size="lg">
+
+          <ButtonGroup size="xs" variant="outline">
+            <Dialog.Trigger asChild>
+              <Button colorPalette="red">
+                <Icon><LuTrash2 /></Icon> Delete selected
+              </Button>
+            </Dialog.Trigger>
+          </ButtonGroup>
+
+          <Portal>
+            <Dialog.Backdrop />
+            <Dialog.Positioner>
+              <Dialog.Content>
+                <Dialog.Header>
+                  <Dialog.Title>Confirm Deletion</Dialog.Title>
+                </Dialog.Header>
+                <Dialog.Body>
+                  <Text mb={2}>Are you sure you want to delete following stat ranges?</Text>
+                  <HStack mb={4} flexWrap="wrap" gap={2}>
+                    {selection.map(id => {
+                      const statRange = statRanges.find(s => s.id === id);
+                      if (!statRange) return null;
+                      return <Badge key={id} colorPalette="blue">{statRange.name}</Badge>
+                    })}
+                  </HStack>
+                  <Text color="fg.muted">Total {selection.length} stat ranges selected</Text>
+                </Dialog.Body>
+                <Dialog.Footer>
+                  <ButtonGroup size="sm">
+                    <Dialog.ActionTrigger asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </Dialog.ActionTrigger>
+                    <Dialog.Context>
+                      {(store) => (
+                        <Button colorPalette="red" onClick={() => handleDeleteStatRanges(selection).then(() => store.setOpen(false))}>
+                          <Icon><LuTrash2 /></Icon>
+                          Delete
+                        </Button>
+                      )}
+                    </Dialog.Context>
+                  </ButtonGroup>
+                </Dialog.Footer>
+                <Dialog.CloseTrigger asChild>
+                  <CloseButton size="sm" />
+                </Dialog.CloseTrigger>
+              </Dialog.Content>
+            </Dialog.Positioner>
+          </Portal>
+        </Dialog.Root>
+      </>
+      )
+    }}
+    topRightElement={topRightElement}
+  />;
+}

--- a/src/app/admin/stat-ranges/[id]/actions.ts
+++ b/src/app/admin/stat-ranges/[id]/actions.ts
@@ -14,8 +14,8 @@ const schema = z
     endDate: z.iso.date(),
     status: z.enum(["ACTIVE", "ARCHIVED"]),
   })
-  .refine((data) => new Date(data.endDate) > new Date(data.startDate), {
-    message: "End date must be after start date",
+  .refine((data) => new Date(data.endDate) >= new Date(data.startDate), {
+    message: "End date must be on or after start date",
     path: ["endDate"],
   });
 

--- a/src/app/admin/stat-ranges/[id]/actions.ts
+++ b/src/app/admin/stat-ranges/[id]/actions.ts
@@ -1,0 +1,65 @@
+"use server";
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+import * as z from "zod";
+
+import { createStatRange, updateStatRange } from "@/lib/data/statrange-dto";
+
+const schema = z
+  .object({
+    id: z.string().optional(),
+    tzOffset: z.coerce.number(),
+    name: z.string().min(1, "Name is required"),
+    startDate: z.iso.date(),
+    endDate: z.iso.date(),
+    status: z.enum(["ACTIVE", "ARCHIVED"]),
+  })
+  .refine((data) => new Date(data.endDate) > new Date(data.startDate), {
+    message: "End date must be after start date",
+    path: ["endDate"],
+  });
+
+export type StatRangeFormState = {
+  issues?: z.ZodError["issues"];
+  prevValues?: Omit<z.infer<typeof schema>, "tzOffset">;
+}
+
+export async function formSubmit(state: StatRangeFormState, formData: FormData): Promise<StatRangeFormState> {
+  const formDataObj = Object.fromEntries(formData.entries());
+
+  try {
+    const parsed: z.infer<typeof schema> = schema.parse(formDataObj);
+
+    const formTzOffset = parsed.tzOffset;
+    const localTzOffset = new Date().getTimezoneOffset();
+    const tzOffset = formTzOffset - localTzOffset;
+
+    const startDate = new Date(new Date(parsed.startDate).getTime() + tzOffset * 60 * 1000);
+    const endDate = new Date(new Date(parsed.endDate).getTime() + tzOffset * 60 * 1000);
+
+    if (parsed.id) {
+      await updateStatRange(parsed.id, {
+        name: parsed.name,
+        startDate: startDate,
+        endDate: endDate,
+        status: parsed.status,
+      });
+    } else {
+      await createStatRange({
+        name: parsed.name,
+        startDate: startDate,
+        endDate: endDate,
+        status: parsed.status,
+      });
+    }
+
+    revalidatePath("/admin/stat-ranges");
+    redirect("/admin/stat-ranges");
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      console.log("Validation errors:", e.issues);
+      return { issues: e.issues, prevValues: formDataObj as never };
+    }
+    throw e;
+  }
+}

--- a/src/app/admin/stat-ranges/[id]/delete/DeleteStatRangeConfirm.tsx
+++ b/src/app/admin/stat-ranges/[id]/delete/DeleteStatRangeConfirm.tsx
@@ -1,0 +1,69 @@
+import { Heading, DataList, HStack, ButtonGroup, Button, Icon, Text, Badge } from "@chakra-ui/react";
+import { LuTrash2 } from "react-icons/lu";
+
+import GenericClipboard from "@/components/Clipboard";
+import { StatRangeDTO } from "@/lib/data/statrange-dto";
+
+export default function DeleteStatRangeConfirm(props: {
+  statRange: StatRangeDTO;
+  handleCancel: () => Promise<void>;
+  handleDelete: () => Promise<void>;
+}) {
+  const { statRange, handleCancel, handleDelete } = props;
+
+  return <>
+    <Heading as="h2" size="md" mb={4}>Confirm Deletion</Heading>
+
+    <DataList.Root mb={4}>
+
+      <DataList.Item>
+        <DataList.ItemLabel>ID</DataList.ItemLabel>
+        <GenericClipboard value={statRange.id} />
+      </DataList.Item>
+
+      <DataList.Item>
+        <DataList.ItemLabel>Name</DataList.ItemLabel>
+        <DataList.ItemValue>{statRange.name}</DataList.ItemValue>
+      </DataList.Item>
+
+      <DataList.Item>
+        <DataList.ItemLabel>Start Date</DataList.ItemLabel>
+        <DataList.ItemValue>{statRange.startDate.toLocaleDateString()}</DataList.ItemValue>
+      </DataList.Item>
+
+      <DataList.Item>
+        <DataList.ItemLabel>End Date</DataList.ItemLabel>
+        <DataList.ItemValue>{statRange.endDate.toLocaleDateString()}</DataList.ItemValue>
+      </DataList.Item>
+
+      <DataList.Item>
+        <DataList.ItemLabel>Status</DataList.ItemLabel>
+        <DataList.ItemValue>
+          <Badge colorPalette={statRange.status === "ACTIVE" ? "green" : "gray"}>
+            {statRange.status}
+          </Badge>
+        </DataList.ItemValue>
+      </DataList.Item>
+
+      <DataList.Item>
+        <DataList.ItemLabel>Created At</DataList.ItemLabel>
+        <DataList.ItemValue>{statRange.createdAt.toLocaleString()}</DataList.ItemValue>
+      </DataList.Item>
+
+    </DataList.Root>
+
+    <Text fontWeight="medium" color="fg.warning" mb={4}>Are you sure you want to delete this stat range?</Text>
+
+    <HStack justify="flex-end">
+      <ButtonGroup size="sm" variant="subtle">
+        <Button onClick={handleCancel}>
+          Cancel
+        </Button>
+        <Button colorPalette="red" onClick={handleDelete}>
+          <Icon><LuTrash2 /></Icon>
+          Delete
+        </Button>
+      </ButtonGroup>
+    </HStack>
+  </>
+}

--- a/src/app/admin/stat-ranges/[id]/delete/page.tsx
+++ b/src/app/admin/stat-ranges/[id]/delete/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from "next/navigation";
+import { Container } from "@chakra-ui/react";
+
+import { deleteStatRange, getStatRangeDTO } from "@/lib/data/statrange-dto";
+import DeleteStatRangeConfirm from "./DeleteStatRangeConfirm";
+
+export default async function DeleteStatRangePage(props: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const { params } = props;
+  const { id } = await params;
+  const searchParams = await props.searchParams;
+
+  const returnTo = typeof searchParams.returnTo === "string" ? searchParams.returnTo : "/admin/stat-ranges";
+
+  const statRangeDTO = await getStatRangeDTO(id);
+  if (!statRangeDTO) {
+    return <Container maxW="md">Stat range not found</Container>;
+  }
+
+  const handleCancel = async () => {
+    "use server";
+    redirect(returnTo);
+  };
+
+  const handleDelete = async () => {
+    "use server";
+    await deleteStatRange(id);
+    redirect(returnTo);
+  };
+
+  return <>
+    <DeleteStatRangeConfirm
+      statRange={statRangeDTO}
+      handleCancel={handleCancel}
+      handleDelete={handleDelete}
+    />
+  </>;
+}

--- a/src/app/admin/stat-ranges/[id]/form.tsx
+++ b/src/app/admin/stat-ranges/[id]/form.tsx
@@ -1,0 +1,148 @@
+"use client";
+import { useActionState, useEffect, useState } from "react";
+import { Fieldset, Stack, Field, DataList, Button, SegmentGroup, SimpleGrid, HStack, Input, GridItem } from "@chakra-ui/react";
+import { LuArchive, LuCircleCheck } from "react-icons/lu";
+
+import { StatRangeDTO } from "@/lib/data/statrange-dto";
+import { formSubmit, StatRangeFormState } from "./actions";
+
+const statusOptions = [
+  {
+    value: "ACTIVE",
+    label: <HStack color="fg.success"><LuCircleCheck />Active</HStack>
+  },
+  {
+    value: "ARCHIVED",
+    label: <HStack color="fg.muted"><LuArchive />Archived</HStack>
+  },
+];
+
+export default function StatRangeForm(props: {
+  isNew?: boolean;
+  statRange?: StatRangeDTO;
+}) {
+  const { isNew, statRange } = props;
+
+  const tzOffset = new Date().getTimezoneOffset();
+
+  const [state, action, pending] = useActionState(formSubmit, {
+    prevValues: statRange ? {
+      id: statRange.id,
+      name: statRange.name,
+      startDate: new Date(statRange.startDate.getTime() - tzOffset * 60 * 1000).toISOString().slice(0, 10),
+      endDate: new Date(statRange.endDate.getTime() - tzOffset * 60 * 1000).toISOString().slice(0, 10),
+      status: statRange.status,
+    } : undefined
+  } as StatRangeFormState);
+
+  const [selectedStatus, setSelectedStatus] = useState<string | null>(state.prevValues?.status || "ACTIVE");
+  useEffect(() => {
+    if (state.prevValues?.status) {
+      setSelectedStatus(state.prevValues.status);
+    }
+  }, [state.prevValues?.status]);
+
+  const nameFieldError = state.issues?.filter((issue: any) => issue.path[0] === "name").map((issue: any) => issue.message).join(", ");
+  const startDateFieldError = state.issues?.filter((issue: any) => issue.path[0] === "startDate").map((issue: any) => issue.message).join(", ");
+  const endDateFieldError = state.issues?.filter((issue: any) => issue.path[0] === "endDate").map((issue: any) => issue.message).join(", ");
+  const statusFieldError = state.issues?.filter((issue: any) => issue.path[0] === "status").map((issue: any) => issue.message).join(", ");
+  const hasFieldErrors = !!(nameFieldError || startDateFieldError || endDateFieldError || statusFieldError);
+
+  return <form action={action}>
+    <Fieldset.Root size="lg" invalid={hasFieldErrors} disabled={pending}>
+      <Stack>
+        <Fieldset.Legend>{isNew ? "Create Stat Range" : "Edit Stat Range"}</Fieldset.Legend>
+        <Fieldset.HelperText>
+          {isNew
+            ? "Create a new named time period for reporting and statistics."
+            : "Edit this stat range's details."}
+        </Fieldset.HelperText>
+      </Stack>
+
+      {statRange && <input type="hidden" name="id" value={statRange.id} />}
+
+      <input type="hidden" name="tzOffset" value={tzOffset} />
+
+      <Fieldset.Content>
+        <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
+          {/* Name */}
+          <GridItem colSpan={{ base: 1, md: 2 }}>
+            <Field.Root required invalid={!!nameFieldError}>
+              <Field.Label>
+                Name
+                <Field.RequiredIndicator />
+              </Field.Label>
+              <Input type="text" name="name" placeholder="Q1 2026" defaultValue={state.prevValues?.name} />
+              <Field.HelperText>A descriptive name for this time period</Field.HelperText>
+              <Field.ErrorText>{nameFieldError}</Field.ErrorText>
+            </Field.Root>
+          </GridItem>
+
+          {/* Start Date */}
+          <Field.Root required invalid={!!startDateFieldError}>
+            <Field.Label>
+              Start Date
+              <Field.RequiredIndicator />
+            </Field.Label>
+            <Input type="date" name="startDate" defaultValue={state.prevValues?.startDate} />
+            <Field.ErrorText>{startDateFieldError}</Field.ErrorText>
+          </Field.Root>
+
+          {/* End Date */}
+          <Field.Root required invalid={!!endDateFieldError}>
+            <Field.Label>
+              End Date
+              <Field.RequiredIndicator />
+            </Field.Label>
+            <Input type="date" name="endDate" defaultValue={state.prevValues?.endDate} />
+            <Field.ErrorText>{endDateFieldError}</Field.ErrorText>
+          </Field.Root>
+
+          {/* Status */}
+          <GridItem colSpan={{ base: 1, md: 2 }}>
+            <Field.Root required invalid={!!statusFieldError}>
+              <Field.Label>
+                Status
+                <Field.RequiredIndicator />
+              </Field.Label>
+
+              <SegmentGroup.Root
+                name="status"
+                size={{ base: "xs", sm: "sm", md: "md" }}
+                value={selectedStatus}
+                onValueChange={({ value }) => setSelectedStatus(value)}
+              >
+                <SegmentGroup.Indicator />
+                <SegmentGroup.Items h={10} items={statusOptions} />
+              </SegmentGroup.Root>
+
+              <Field.HelperText>Active ranges are available for selection in reports</Field.HelperText>
+              <Field.ErrorText>{statusFieldError}</Field.ErrorText>
+            </Field.Root>
+          </GridItem>
+        </SimpleGrid>
+      </Fieldset.Content>
+
+      {statRange && (
+        <DataList.Root orientation="horizontal">
+          <DataList.Item>
+            <DataList.ItemLabel>Created At</DataList.ItemLabel>
+            <DataList.ItemValue>{statRange.createdAt.toLocaleString()}</DataList.ItemValue>
+          </DataList.Item>
+          <DataList.Item>
+            <DataList.ItemLabel>Last Updated At</DataList.ItemLabel>
+            <DataList.ItemValue>{statRange.updatedAt.toLocaleString()}</DataList.ItemValue>
+          </DataList.Item>
+        </DataList.Root>
+      )}
+
+      <Button type="submit" loading={pending}>
+        {isNew ? "Create" : "Save Changes"}
+      </Button>
+
+      <Fieldset.ErrorText>
+        Some fields are invalid. Please check the errors above.
+      </Fieldset.ErrorText>
+    </Fieldset.Root>
+  </form>;
+}

--- a/src/app/admin/stat-ranges/[id]/layout.tsx
+++ b/src/app/admin/stat-ranges/[id]/layout.tsx
@@ -1,0 +1,11 @@
+import { Container, Card } from "@chakra-ui/react";
+
+export default function StatRangeLayout({ children }: { children: React.ReactNode }) {
+  return <Container maxWidth="5xl">
+    <Card.Root variant="elevated">
+      <Card.Body>
+        {children}
+      </Card.Body>
+    </Card.Root>
+  </Container>;
+}

--- a/src/app/admin/stat-ranges/[id]/page.tsx
+++ b/src/app/admin/stat-ranges/[id]/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { HStack, Button, Icon, IconButton, Container } from "@chakra-ui/react";
+import { LuArrowLeft, LuTrash2 } from "react-icons/lu";
+
+import { getStatRangeDTO } from "@/lib/data/statrange-dto";
+import StatRangeForm from "./form";
+
+export default async function SingleStatRangePage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const { params } = props;
+  const { id } = await params;
+
+  const isNew = id === "new";
+  const statRangeDTO = !isNew ? await getStatRangeDTO(id) : null;
+
+  return (<>
+    <HStack mb={4} justifyContent="space-between">
+      <Button size="xs" variant="ghost" asChild>
+        <Link href="/admin/stat-ranges">
+          <Icon><LuArrowLeft /></Icon>
+          Back to Stat Ranges
+        </Link>
+      </Button>
+
+      {statRangeDTO &&
+        <IconButton size="xs" variant="ghost" colorPalette="red" asChild><Link href={`/admin/stat-ranges/${statRangeDTO?.id}/delete`}>
+          <Icon><LuTrash2 /></Icon>
+        </Link></IconButton>
+      }
+    </HStack>
+
+    <Container>
+      <StatRangeForm isNew={isNew} statRange={statRangeDTO ?? undefined} />
+    </Container>
+  </>);
+}

--- a/src/app/admin/stat-ranges/actions.ts
+++ b/src/app/admin/stat-ranges/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+import { revalidatePath } from "next/cache";
+
+import { deleteStatRanges } from "@/lib/data/statrange-dto";
+
+export async function handleDeleteStatRanges(ids: string[]) {
+  await deleteStatRanges(ids);
+
+  revalidatePath("/admin/stat-ranges");
+}

--- a/src/app/admin/stat-ranges/page.tsx
+++ b/src/app/admin/stat-ranges/page.tsx
@@ -1,0 +1,14 @@
+import { Pagination } from "@chakra-ui/react";
+
+import { getAllStatRangeDTOs } from "@/lib/data/statrange-dto";
+import StatRangesTable from "./StatRangesTable";
+
+export default async function StatRangesPage() {
+  const statRanges = await getAllStatRangeDTOs();
+
+  return <>
+    <Pagination.Root count={statRanges.length} defaultPageSize={10} defaultPage={1}>
+      <StatRangesTable statRanges={statRanges} />
+    </Pagination.Root>
+  </>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { getTranslations } from "next-intl/server";
 import { SessionProvider } from "next-auth/react";
 
 import { Avatar, Box, Button, CloseButton, Container, Drawer, Flex, Heading, HStack, Icon, IconButton, Menu, MenuSelectionDetails, Portal, Separator, Stack, Text } from "@chakra-ui/react";
-import { LuLogOut, LuLogIn, LuMenu, LuChartNoAxesCombined, LuLogs, LuUsers } from "react-icons/lu";
+import { LuLogOut, LuLogIn, LuMenu, LuChartNoAxesCombined, LuLogs, LuUsers, LuCalendarRange } from "react-icons/lu";
 
 import { auth, Role, signIn, signOut } from "@/auth";
 import { ColorModeButton } from "@/components/ui/color-mode";
@@ -90,6 +90,7 @@ async function NavBar(props: {
     { href: "/logs", label: t("nav.logs"), icon: LuLogs, roles: [Role.USER, Role.ADMIN] },
     { href: "/report", label: t("nav.reports"), icon: LuChartNoAxesCombined, roles: [Role.ADMIN] },
     { href: "/admin/users", label: t("nav.users"), icon: LuUsers, roles: [Role.ADMIN] },
+    { href: "/admin/stat-ranges", label: t("nav.statRanges"), icon: LuCalendarRange, roles: [Role.ADMIN] },
   ];
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,8 @@ import { LuChevronsRight, LuHouse, LuTrophy } from "react-icons/lu";
 
 import { auth, Role } from "@/auth";
 import LastUpdatedText from "@/components/LastUpdatedText";
-import LeaderboardTable from "@/components/LeaderboardTable";
+import LeaderboardCard from "./_components/LeaderboardCard";
+import LeaderboardWithFilter from "./_components/LeaderboardWithFilter";
 import { getTeamsForUser } from "@/lib/data/team-dto";
 import {
   adminClockOut, adminLockLog, getAllCurrentlyInTimelogDTOs, getAllUsersTotalTimeSec, getUserLastLogDTO, TimeLogDTO,
@@ -155,42 +156,7 @@ export default async function Home() {
             )}
 
             {/* Leaderboard Card */}
-            <Dialog.Root>
-              <Card.Root w="full" size="sm">
-                <Card.Header>
-                  <Card.Title>{t("leaderboardCard.title")}</Card.Title>
-                </Card.Header>
-                <Card.Body>
-                  <LeaderboardTable rankings={rankings} limits={5} />
-                </Card.Body>
-                <Card.Footer>
-                  <Text fontSize="sm" color="gray.500">{t("leaderboardCard.footerText")}</Text>
-                  <Dialog.Trigger asChild>
-                    <Button size="xs" mt={2}>
-                      {t("leaderboardCard.viewMore")}
-                      <Icon><LuChevronsRight /></Icon>
-                    </Button>
-                  </Dialog.Trigger>
-                </Card.Footer>
-              </Card.Root>
-
-              <Portal>
-                <Dialog.Backdrop />
-                <Dialog.Positioner>
-                  <Dialog.Content>
-                    <Dialog.Header>
-                      <Dialog.Title>{t("leaderboardCard.viewMoreDialog.title")}</Dialog.Title>
-                    </Dialog.Header>
-                    <Dialog.Body>
-                      <LeaderboardTable rankings={rankings} />
-                    </Dialog.Body>
-                    <Dialog.CloseTrigger asChild>
-                      <CloseButton size="sm" />
-                    </Dialog.CloseTrigger>
-                  </Dialog.Content>
-                </Dialog.Positioner>
-              </Portal>
-            </Dialog.Root>
+            <LeaderboardCard initialRankings={rankings} />
 
           </VStack>
         </GridItem>
@@ -241,7 +207,7 @@ export default async function Home() {
         </Tabs.Content>
 
         <Tabs.Content value="leaderboard">
-          <LeaderboardTable rankings={rankings} />
+          <LeaderboardWithFilter initialRankings={rankings} />
         </Tabs.Content>
 
       </Tabs.Root>

--- a/src/app/report/daily/DailyReportContent.tsx
+++ b/src/app/report/daily/DailyReportContent.tsx
@@ -5,6 +5,7 @@ import { LuArrowLeft, LuArrowRight, LuRefreshCcw } from "react-icons/lu";
 
 import Heatmap from "@/components/HeatMap";
 import StatValueTextDuration from "@/components/StatValueTextDuration";
+import StatRangeSelector from "@/components/StatRangeSelector";
 import { DailyReportData, getDailyReportData } from "@/lib/data/report";
 
 export default function DailyReportContent(props: {
@@ -34,6 +35,12 @@ export default function DailyReportContent(props: {
 
   const handleDateInputOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newDate = new Date(e.target.value);
+    newDate.setHours(0, 0, 0, 0);
+    setStart(newDate);
+  }
+
+  const handleStatRangeSelect = (startDate: Date, endDate: Date) => {
+    const newDate = new Date(startDate);
     newDate.setHours(0, 0, 0, 0);
     setStart(newDate);
   }
@@ -82,7 +89,8 @@ export default function DailyReportContent(props: {
   return (<>
     <HStack justify="space-between" mb={4}>
       <Heading as="h2" size="2xl">Daily Report</Heading>
-      <HStack>
+      <HStack gap={3}>
+        <StatRangeSelector onSelectAction={handleStatRangeSelect} />
         <ButtonGroup size="sm" variant="ghost" gap={1}>
           <IconButton aria-label="Previous Day" onClick={handlePreviousDay}><LuArrowLeft /></IconButton>
           <Input type="date" size="xs" value={dateInputValue} onChange={handleDateInputOnChange} />

--- a/src/app/report/daily/DailyReportContent.tsx
+++ b/src/app/report/daily/DailyReportContent.tsx
@@ -5,7 +5,6 @@ import { LuArrowLeft, LuArrowRight, LuRefreshCcw } from "react-icons/lu";
 
 import Heatmap from "@/components/HeatMap";
 import StatValueTextDuration from "@/components/StatValueTextDuration";
-import StatRangeSelector from "@/components/StatRangeSelector";
 import { DailyReportData, getDailyReportData } from "@/lib/data/report";
 
 export default function DailyReportContent(props: {
@@ -35,12 +34,6 @@ export default function DailyReportContent(props: {
 
   const handleDateInputOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newDate = new Date(e.target.value);
-    newDate.setHours(0, 0, 0, 0);
-    setStart(newDate);
-  }
-
-  const handleStatRangeSelect = (startDate: Date, endDate: Date) => {
-    const newDate = new Date(startDate);
     newDate.setHours(0, 0, 0, 0);
     setStart(newDate);
   }
@@ -90,7 +83,6 @@ export default function DailyReportContent(props: {
     <HStack justify="space-between" mb={4}>
       <Heading as="h2" size="2xl">Daily Report</Heading>
       <HStack gap={3}>
-        <StatRangeSelector onSelectAction={handleStatRangeSelect} />
         <ButtonGroup size="sm" variant="ghost" gap={1}>
           <IconButton aria-label="Previous Day" onClick={handlePreviousDay}><LuArrowLeft /></IconButton>
           <Input type="date" size="xs" value={dateInputValue} onChange={handleDateInputOnChange} />

--- a/src/components/StatRangeSelector.tsx
+++ b/src/components/StatRangeSelector.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { NativeSelectRoot, NativeSelectField } from "@chakra-ui/react";
+
+import { StatRangeDTO } from "@/lib/data/statrange-dto";
+import { getActiveStatRanges } from "./actions";
+
+export default function StatRangeSelector(props: {
+  onSelectAction?: (startDate: Date, endDate: Date) => void;
+}) {
+  const { onSelectAction } = props;
+  const t = useTranslations("StatRangeSelector");
+
+  const [statRanges, setStatRanges] = useState<StatRangeDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [selectedId, setSelectedId] = useState("");
+
+  useEffect(() => {
+    getActiveStatRanges()
+      .then((ranges: StatRangeDTO[]) => setStatRanges(ranges))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value;
+    setSelectedId(id);
+    if (!id) return;
+
+    const selectedRange = statRanges.find(range => range.id === id);
+    if (selectedRange && onSelectAction) {
+      onSelectAction(selectedRange.startDate, selectedRange.endDate);
+    }
+  };
+
+  if (error || (!loading && statRanges.length === 0)) {
+    return null;
+  }
+
+  return (
+    <NativeSelectRoot size="xs" w="auto" minW="32" disabled={loading}>
+      <NativeSelectField
+        aria-label={t("label")}
+        value={selectedId}
+        onChange={handleChange}
+      >
+        <option value="">{loading ? t("loading") : t("placeholder")}</option>
+        {statRanges.map((range) => (
+          <option key={range.id} value={range.id}>
+            {range.name}
+          </option>
+        ))}
+      </NativeSelectField>
+    </NativeSelectRoot>
+  );
+}

--- a/src/components/StatRangeSelector.tsx
+++ b/src/components/StatRangeSelector.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ChangeEvent } from "react";
 import { useTranslations } from "next-intl";
 import { NativeSelectRoot, NativeSelectField } from "@chakra-ui/react";
 
@@ -24,7 +24,7 @@ export default function StatRangeSelector(props: {
       .finally(() => setLoading(false));
   }, []);
 
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const id = e.target.value;
     setSelectedId(id);
     if (!id) return;

--- a/src/components/StatRangeSelector.tsx
+++ b/src/components/StatRangeSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { useEffect, useState, type ChangeEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import { NativeSelectRoot, NativeSelectField } from "@chakra-ui/react";
+import { createListCollection, Select, Portal } from "@chakra-ui/react";
 
 import { StatRangeDTO } from "@/lib/data/statrange-dto";
 import { getActiveStatRanges } from "./actions";
@@ -25,8 +25,15 @@ export default function StatRangeSelector(props: {
       .finally(() => setLoading(false));
   }, []);
 
-  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const id = e.target.value;
+  const collection = useMemo(() => createListCollection({
+    items: [
+      { label: t("all"), value: "" },
+      ...statRanges.map(range => ({ label: range.name, value: range.id })),
+    ],
+  }), [statRanges, t]);
+
+  const handleValueChange = ({ value }: { value: string[] }) => {
+    const id = value[0] ?? "";
     setSelectedId(id);
     if (!id) {
       onClearAction?.();
@@ -43,19 +50,36 @@ export default function StatRangeSelector(props: {
   }
 
   return (
-    <NativeSelectRoot size="xs" w="auto" minW="32" disabled={loading}>
-      <NativeSelectField
-        aria-label={t("label")}
-        value={selectedId}
-        onChange={handleChange}
-      >
-        <option value="">{loading ? t("loading") : t("all")}</option>
-        {statRanges.map((range) => (
-          <option key={range.id} value={range.id}>
-            {range.name}
-          </option>
-        ))}
-      </NativeSelectField>
-    </NativeSelectRoot>
+    <Select.Root
+      collection={collection}
+      size="xs"
+      w="auto"
+      minW="44"
+      value={[selectedId]}
+      onValueChange={handleValueChange}
+      disabled={loading}
+    >
+      <Select.HiddenSelect />
+      <Select.Control>
+        <Select.Trigger>
+          <Select.ValueText placeholder={loading ? t("loading") : t("all")} />
+        </Select.Trigger>
+        <Select.IndicatorGroup>
+          <Select.Indicator />
+        </Select.IndicatorGroup>
+      </Select.Control>
+      <Portal>
+        <Select.Positioner>
+          <Select.Content>
+            {collection.items.map(item => (
+              <Select.Item item={item} key={item.value}>
+                {item.label}
+                <Select.ItemIndicator />
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Positioner>
+      </Portal>
+    </Select.Root>
   );
 }

--- a/src/components/StatRangeSelector.tsx
+++ b/src/components/StatRangeSelector.tsx
@@ -45,7 +45,7 @@ export default function StatRangeSelector(props: {
     }
   };
 
-  if (error || (!loading && statRanges.length === 0)) {
+  if (loading || error || statRanges.length === 0) {
     return null;
   }
 
@@ -57,12 +57,11 @@ export default function StatRangeSelector(props: {
       minW="44"
       value={[selectedId]}
       onValueChange={handleValueChange}
-      disabled={loading}
     >
       <Select.HiddenSelect />
       <Select.Control>
         <Select.Trigger>
-          <Select.ValueText placeholder={loading ? t("loading") : t("all")} />
+          <Select.ValueText placeholder={t("all")} />
         </Select.Trigger>
         <Select.IndicatorGroup>
           <Select.Indicator />

--- a/src/components/StatRangeSelector.tsx
+++ b/src/components/StatRangeSelector.tsx
@@ -8,8 +8,9 @@ import { getActiveStatRanges } from "./actions";
 
 export default function StatRangeSelector(props: {
   onSelectAction?: (startDate: Date, endDate: Date) => void;
+  onClearAction?: () => void;
 }) {
-  const { onSelectAction } = props;
+  const { onSelectAction, onClearAction } = props;
   const t = useTranslations("StatRangeSelector");
 
   const [statRanges, setStatRanges] = useState<StatRangeDTO[]>([]);
@@ -27,8 +28,10 @@ export default function StatRangeSelector(props: {
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const id = e.target.value;
     setSelectedId(id);
-    if (!id) return;
-
+    if (!id) {
+      onClearAction?.();
+      return;
+    }
     const selectedRange = statRanges.find(range => range.id === id);
     if (selectedRange && onSelectAction) {
       onSelectAction(selectedRange.startDate, selectedRange.endDate);
@@ -46,7 +49,7 @@ export default function StatRangeSelector(props: {
         value={selectedId}
         onChange={handleChange}
       >
-        <option value="">{loading ? t("loading") : t("placeholder")}</option>
+        <option value="">{loading ? t("loading") : t("all")}</option>
         {statRanges.map((range) => (
           <option key={range.id} value={range.id}>
             {range.name}

--- a/src/components/actions.ts
+++ b/src/components/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { getActiveStatRangeDTOs } from "@/lib/data/statrange-dto";
+
+export async function getActiveStatRanges() {
+  return await getActiveStatRangeDTOs();
+}

--- a/src/lib/data/statrange-dto.ts
+++ b/src/lib/data/statrange-dto.ts
@@ -1,0 +1,179 @@
+import "server-only";
+import { auth, Role } from "@/auth";
+import { StatRange } from "@/generated/prisma";
+import prisma from "../prisma";
+
+export type StatRangeDTO = {
+  id: string;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  status: "ACTIVE" | "ARCHIVED";
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export function prismaStatRangeToDTO(statRange: StatRange): StatRangeDTO {
+  let status: StatRangeDTO["status"];
+  if (statRange.status === "Active") {
+    status = "ACTIVE";
+  } else if (statRange.status === "Archived") {
+    status = "ARCHIVED";
+  } else {
+    throw new Error("Unknown StatRange status");
+  }
+
+  return {
+    id: statRange.id,
+    name: statRange.name,
+    startDate: new Date(statRange.startDate),
+    endDate: new Date(statRange.endDate),
+    status,
+    createdAt: new Date(statRange.createdAt),
+    updatedAt: new Date(statRange.updatedAt),
+  };
+}
+
+export async function getStatRangeDTO(id: string): Promise<StatRangeDTO | null> {
+  const session = await auth();
+
+  if (!session || session.user.role !== Role.ADMIN) {
+    return null;
+  }
+
+  const statRange = await prisma.statRange.findUnique({
+    where: { id },
+  });
+
+  if (!statRange) {
+    return null;
+  }
+
+  return prismaStatRangeToDTO(statRange);
+}
+
+export async function getAllStatRangeDTOs(): Promise<StatRangeDTO[]> {
+  const session = await auth();
+
+  if (!session || session.user.role !== Role.ADMIN) {
+    return [];
+  }
+
+  const statRanges = await prisma.statRange.findMany({
+    orderBy: { startDate: "desc" },
+  });
+
+  return statRanges.map(prismaStatRangeToDTO);
+}
+
+export async function getActiveStatRangeDTOs(): Promise<StatRangeDTO[]> {
+  const session = await auth();
+
+  if (!session) {
+    return [];
+  }
+
+  const statRanges = await prisma.statRange.findMany({
+    where: { status: "Active" },
+    orderBy: { startDate: "desc" },
+  });
+
+  return statRanges.map(prismaStatRangeToDTO);
+}
+
+export async function createStatRange(data: {
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  status: StatRangeDTO["status"];
+}): Promise<StatRangeDTO> {
+  const session = await auth();
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  if (session.user.role !== Role.ADMIN) {
+    throw new Error("Forbidden");
+  }
+
+  const statRange = await prisma.statRange.create({
+    data: {
+      name: data.name,
+      startDate: data.startDate,
+      endDate: data.endDate,
+      status: data.status === "ACTIVE" ? "Active" : "Archived",
+    },
+  });
+
+  return prismaStatRangeToDTO(statRange);
+}
+
+export async function updateStatRange(id: string, data: {
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  status: StatRangeDTO["status"];
+}): Promise<StatRangeDTO | null> {
+  const session = await auth();
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  if (session.user.role !== Role.ADMIN) {
+    throw new Error("Forbidden");
+  }
+
+  const statRange = await prisma.statRange.update({
+    where: { id },
+    data: {
+      name: data.name,
+      startDate: data.startDate,
+      endDate: data.endDate,
+      status: data.status === "ACTIVE" ? "Active" : "Archived",
+    },
+  });
+
+  if (!statRange) {
+    return null;
+  }
+
+  return prismaStatRangeToDTO(statRange);
+}
+
+export async function deleteStatRange(id: string): Promise<StatRangeDTO> {
+  const session = await auth();
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  if (session.user.role !== Role.ADMIN) {
+    throw new Error("Forbidden");
+  }
+
+  const statRange = await prisma.statRange.delete({
+    where: { id },
+  });
+
+  return prismaStatRangeToDTO(statRange);
+}
+
+export async function deleteStatRanges(ids: string[]) {
+  const session = await auth();
+
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+
+  if (session.user.role !== Role.ADMIN) {
+    throw new Error("Forbidden");
+  }
+
+  const payload = await prisma.statRange.deleteMany({
+    where: { id: { in: ids } },
+  });
+
+  return payload;
+}

--- a/src/lib/data/statrange-dto.ts
+++ b/src/lib/data/statrange-dto.ts
@@ -114,7 +114,7 @@ export async function updateStatRange(id: string, data: {
   startDate: Date;
   endDate: Date;
   status: StatRangeDTO["status"];
-}): Promise<StatRangeDTO | null> {
+}): Promise<StatRangeDTO> {
   const session = await auth();
 
   if (!session) {
@@ -134,10 +134,6 @@ export async function updateStatRange(id: string, data: {
       status: data.status === "ACTIVE" ? "Active" : "Archived",
     },
   });
-
-  if (!statRange) {
-    return null;
-  }
 
   return prismaStatRangeToDTO(statRange);
 }

--- a/src/lib/data/timelog-dto.ts
+++ b/src/lib/data/timelog-dto.ts
@@ -153,16 +153,8 @@ export async function getAllUsersTotalTimeSec(opts?: {
     // Use MongoDB extended JSON format for dates in aggregateRaw
     matchStage["$expr"] = {
       $and: [
-        {
-          $expr: {
-            $lt: ["$inTime", { $dateFromString: { dateString: end.toISOString() } }]
-          }
-        },
-        {
-          $expr: {
-            $gte: ["$outTime", { $dateFromString: { dateString: start.toISOString() } }]
-          }
-        }
+        { $lt: ["$inTime", { $dateFromString: { dateString: end.toISOString() } }] },
+        { $gte: ["$outTime", { $dateFromString: { dateString: start.toISOString() } }] },
       ]
     };
   } else if (startDate) {

--- a/src/lib/data/timelog-dto.ts
+++ b/src/lib/data/timelog-dto.ts
@@ -130,13 +130,60 @@ export type UserClockStatus = {
   totalTimeSec: number;
 }
 
-export async function getAllUsersTotalTimeSec(): Promise<{ [userId: string]: number }> {
+export async function getAllUsersTotalTimeSec(opts?: {
+  startDate?: Date;
+  endDate?: Date;
+}): Promise<{ [userId: string]: number }> {
+  const { startDate, endDate } = opts || {};
+
+  const matchStage: any = {
+    status: "Done",
+  };
+
+  // Add date range filter if provided
+  // A time log overlaps with the date range if:
+  // - It starts before the range ends AND ends after the range starts
+  if (startDate && endDate) {
+    // Convert to Date objects if they're strings (from client serialization)
+    const start = new Date(startDate);
+    // Add one day to endDate to make it inclusive (since endDate is typically start of day)
+    const end = new Date(endDate);
+    end.setDate(end.getDate() + 1); // Move to start of next day to include all of endDate
+
+    // Use MongoDB extended JSON format for dates in aggregateRaw
+    matchStage["$expr"] = {
+      $and: [
+        {
+          $expr: {
+            $lt: ["$inTime", { $dateFromString: { dateString: end.toISOString() } }]
+          }
+        },
+        {
+          $expr: {
+            $gte: ["$outTime", { $dateFromString: { dateString: start.toISOString() } }]
+          }
+        }
+      ]
+    };
+  } else if (startDate) {
+    const start = new Date(startDate);
+
+    matchStage["$expr"] = {
+      $gte: ["$outTime", { $dateFromString: { dateString: start.toISOString() } }]
+    };
+  } else if (endDate) {
+    const end = new Date(endDate);
+    end.setDate(end.getDate() + 1); // Make it inclusive
+
+    matchStage["$expr"] = {
+      $lt: ["$inTime", { $dateFromString: { dateString: end.toISOString() } }]
+    };
+  }
+
   const result = await prisma.timeLog.aggregateRaw({
     pipeline: [
       {
-        $match: {
-          status: "Done",
-        }
+        $match: matchStage,
       },
       {
         $addFields: {


### PR DESCRIPTION
## Summary

- 新增 **StatRange** 資料模型，讓管理員可以建立具名的日期區間（如「2026 FRC Season」）
- Admin CRUD 頁面 `/admin/stat-ranges`：列表排序、單筆/批次刪除、分頁、新增/編輯表單
- **LeaderboardCard**（桌面版）與 **LeaderboardWithFilter**（行動版）標題右側加入 range selector，選 range 篩選排行榜，選 "All" 回到全時段
- `timelog-dto` 的 MongoDB aggregation 支援 startDate/endDate 篩選（修正原本 nested `$expr` 導致篩選無效的問題）
- StatRangeSelector 未登入、無 active range、或載入中時完全隱藏（不閃爍）
- 使用 Chakra UI 自訂 Select 取代 native select，對齊更一致
- i18n：新增 en / zh-TW 字串

## Changes since first review

- 修正 `timelog-dto` MongoDB `$and` 裡 nested `$expr`（原本篩選完全沒生效）
- 修正 `updateStatRange` return type（移除 unreachable `null`）
- 允許同日 range（end date 驗證改為 `>=`）
- 將 Clear 按鈕改為 select 內建 "All" 選項，UX 更一致
- 移除 `LeaderboardCard` 的 unused imports（`useEffect`、`VStack`）
- 修正 `StatRangeSelector` 的型別標注（`ChangeEvent` 明確 import）
- 移除 Daily Report 頁面的 StatRangeSelector（不適用）
- 改用 Chakra UI 自訂 Select（解決 native select 展開時文字對齊問題）
- loading 期間隱藏 selector，修正未登入時的閃爍問題

## Test plan

- [x] Admin 建立 StatRange（ACTIVE），回到首頁確認 Leaderboard 出現 selector
- [x] 選擇 range → 排行榜資料更新；切回 "All" → 回到全時段
- [x] 行動版 Leaderboard tab → 點 calendar icon → popover 選 range → 篩選生效；選 "All" 重置
- [x] 未登入時 selector 不出現（不閃爍）
- [x] Admin 封存 StatRange → selector 不再顯示該選項
- [x] 建立同日 range（startDate = endDate）→ 應成功儲存
- [x] Daily Report 頁面不出現 selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)