### PR TITLE
feat: add API-key authenticated Admin API for users and time logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Admin API
+
+An API-key authenticated REST API is available for managing users and time logs from
+external systems. Set `ADMIN_API_KEY` in the environment, then send it as a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_API_KEY" http://localhost:3000/api/admin/users
+```
+
+Endpoints:
+
+- `GET /api/admin/users` / `POST /api/admin/users`
+- `GET /api/admin/users/{id}` / `PUT /api/admin/users/{id}` / `DELETE /api/admin/users/{id}`
+- `GET /api/admin/timelogs` / `POST /api/admin/timelogs`
+- `GET /api/admin/timelogs/{id}` / `PUT /api/admin/timelogs/{id}` / `DELETE /api/admin/timelogs/{id}`
+
+The full OpenAPI 3.0 schema is available at [`/openapi/admin-api.json`](public/openapi/admin-api.json).
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/public/openapi/admin-api.json
+++ b/public/openapi/admin-api.json
@@ -1,0 +1,494 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "OverHours Admin API",
+    "description": "Admin API for managing users and time logs. Authenticated with a static Bearer API key (ADMIN_API_KEY).",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/api"
+    }
+  ],
+  "security": [
+    { "bearerAuth": [] }
+  ],
+  "tags": [
+    { "name": "Users" },
+    { "name": "TimeLogs" }
+  ],
+  "paths": {
+    "/admin/users": {
+      "get": {
+        "tags": ["Users"],
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": false,
+            "description": "Case-insensitive substring filter on email",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/User" }
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      },
+      "post": {
+        "tags": ["Users"],
+        "summary": "Create a user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserCreate" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/User" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "409": { "$ref": "#/components/responses/Conflict" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      }
+    },
+    "/admin/users/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": ["Users"],
+        "summary": "Get a user by id",
+        "responses": {
+          "200": {
+            "description": "The user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/User" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      },
+      "put": {
+        "tags": ["Users"],
+        "summary": "Update a user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserUpdate" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/User" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "409": { "$ref": "#/components/responses/Conflict" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      },
+      "delete": {
+        "tags": ["Users"],
+        "summary": "Delete a user",
+        "responses": {
+          "200": {
+            "description": "User deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/User" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      }
+    },
+    "/admin/timelogs": {
+      "get": {
+        "tags": ["TimeLogs"],
+        "summary": "List time logs",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TimeLogStatus" }
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "required": false,
+            "description": "ISO 8601 datetime; matches logs overlapping [startTime, endTime)",
+            "schema": { "type": "string", "format": "date-time" }
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "required": false,
+            "description": "ISO 8601 datetime; matches logs overlapping [startTime, endTime)",
+            "schema": { "type": "string", "format": "date-time" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of time logs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/TimeLog" }
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      },
+      "post": {
+        "tags": ["TimeLogs"],
+        "summary": "Create a time log",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TimeLogCreate" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Time log created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/TimeLog" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      }
+    },
+    "/admin/timelogs/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "tags": ["TimeLogs"],
+        "summary": "Get a time log by id",
+        "responses": {
+          "200": {
+            "description": "The time log",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/TimeLog" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      },
+      "put": {
+        "tags": ["TimeLogs"],
+        "summary": "Update a time log",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TimeLogUpdate" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Time log updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/TimeLog" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      },
+      "delete": {
+        "tags": ["TimeLogs"],
+        "summary": "Delete a time log",
+        "responses": {
+          "200": {
+            "description": "Time log deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/TimeLog" }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotConfigured" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Static admin API key, set via the ADMIN_API_KEY environment variable"
+      }
+    },
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "example": "665f1c2e8a1b2c3d4e5f6789" },
+          "email": { "type": "string", "format": "email" },
+          "name": { "type": "string" },
+          "image": { "type": "string", "format": "uri", "nullable": true },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "email", "name", "createdAt", "updatedAt"]
+      },
+      "UserCreate": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "format": "email" },
+          "name": { "type": "string", "minLength": 1 }
+        },
+        "required": ["email", "name"]
+      },
+      "UserUpdate": {
+        "type": "object",
+        "properties": {
+          "email": { "type": "string", "format": "email" },
+          "name": { "type": "string", "minLength": 1 }
+        },
+        "required": ["email", "name"]
+      },
+      "TimeLogStatus": {
+        "type": "string",
+        "enum": ["CURRENTLY_IN", "DONE", "LOCKED"]
+      },
+      "TimeLog": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "userId": { "type": "string" },
+          "status": { "$ref": "#/components/schemas/TimeLogStatus" },
+          "inTime": { "type": "string", "format": "date-time" },
+          "outTime": { "type": "string", "format": "date-time", "nullable": true },
+          "notes": { "type": "string", "nullable": true },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "userId", "status", "inTime", "createdAt", "updatedAt"]
+      },
+      "TimeLogCreate": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "string" },
+          "status": { "$ref": "#/components/schemas/TimeLogStatus" },
+          "inTime": { "type": "string", "format": "date-time" },
+          "outTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Required when status is DONE or LOCKED"
+          },
+          "notes": { "type": "string" }
+        },
+        "required": ["userId", "status", "inTime"]
+      },
+      "TimeLogUpdate": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "string" },
+          "status": { "$ref": "#/components/schemas/TimeLogStatus" },
+          "inTime": { "type": "string", "format": "date-time" },
+          "outTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Required when status is DONE or LOCKED"
+          },
+          "notes": { "type": "string" }
+        },
+        "required": ["userId", "status", "inTime"]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "issues": {
+            "type": "array",
+            "items": { "type": "object" }
+          }
+        },
+        "required": ["error"]
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Missing or invalid Bearer API key",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Resource conflict (e.g. duplicate email)",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "Request validation failed",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotConfigured": {
+        "description": "Admin API is not configured (ADMIN_API_KEY not set)",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/app/api/admin/timelogs/[id]/route.ts
+++ b/src/app/api/admin/timelogs/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as z from "zod";
+
+import { verifyAdminApiKey } from "@/lib/admin-api-auth";
+import { adminDeleteTimeLog, adminGetTimeLog, adminUpdateTimeLog } from "@/lib/data/timelog-dto";
+
+const updateSchema = z.object({
+  userId: z.string().trim().nonempty(),
+  status: z.enum(["CURRENTLY_IN", "DONE", "LOCKED"]),
+  inTime: z.iso.datetime().transform(v => new Date(v)),
+  outTime: z.iso.datetime().transform(v => new Date(v)).optional(),
+  notes: z.string().trim().nonempty().optional(),
+});
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+function isKnownValidationError(e: unknown): e is Error {
+  return e instanceof Error && (
+    e.message === "Out time is required for DONE or LOCKED status"
+    || e.message === "Out time must be after in time"
+  );
+}
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { id } = await params;
+  const timeLog = await adminGetTimeLog(id);
+
+  if (!timeLog) {
+    return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ data: timeLog });
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const parsed = updateSchema.parse(body);
+    const timeLog = await adminUpdateTimeLog(id, parsed);
+
+    return NextResponse.json({ data: timeLog });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json({ error: "Validation failed", issues: e.issues }, { status: 400 });
+    }
+
+    if (isKnownValidationError(e)) {
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    }
+
+    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2025") {
+      return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+    }
+
+    throw e;
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { id } = await params;
+
+  try {
+    const timeLog = await adminDeleteTimeLog(id);
+    return NextResponse.json({ data: timeLog });
+  } catch (e) {
+    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2025") {
+      return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+    }
+
+    throw e;
+  }
+}

--- a/src/app/api/admin/timelogs/[id]/route.ts
+++ b/src/app/api/admin/timelogs/[id]/route.ts
@@ -3,9 +3,10 @@ import * as z from "zod";
 
 import { verifyAdminApiKey } from "@/lib/admin-api-auth";
 import { adminDeleteTimeLog, adminGetTimeLog, adminUpdateTimeLog } from "@/lib/data/timelog-dto";
+import { objectIdSchema } from "@/lib/objectid";
 
 const updateSchema = z.object({
-  userId: z.string().trim().nonempty(),
+  userId: objectIdSchema,
   status: z.enum(["CURRENTLY_IN", "DONE", "LOCKED"]),
   inTime: z.iso.datetime().transform(v => new Date(v)),
   outTime: z.iso.datetime().transform(v => new Date(v)).optional(),
@@ -21,11 +22,19 @@ function isKnownValidationError(e: unknown): e is Error {
   );
 }
 
+function invalidIdResponse() {
+  return NextResponse.json({ error: "Invalid id format" }, { status: 400 });
+}
+
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const authError = verifyAdminApiKey(req);
   if (authError) return authError;
 
   const { id } = await params;
+  if (!objectIdSchema.safeParse(id).success) {
+    return invalidIdResponse();
+  }
+
   const timeLog = await adminGetTimeLog(id);
 
   if (!timeLog) {
@@ -40,6 +49,9 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
   if (authError) return authError;
 
   const { id } = await params;
+  if (!objectIdSchema.safeParse(id).success) {
+    return invalidIdResponse();
+  }
 
   let body: unknown;
   try {
@@ -62,8 +74,14 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: e.message }, { status: 400 });
     }
 
-    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2025") {
-      return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+    if (e instanceof Error && "code" in e) {
+      const code = (e as { code: string }).code;
+      if (code === "P2025") {
+        return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+      }
+      if (code === "P2023") {
+        return invalidIdResponse();
+      }
     }
 
     throw e;
@@ -75,13 +93,22 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
   if (authError) return authError;
 
   const { id } = await params;
+  if (!objectIdSchema.safeParse(id).success) {
+    return invalidIdResponse();
+  }
 
   try {
     const timeLog = await adminDeleteTimeLog(id);
     return NextResponse.json({ data: timeLog });
   } catch (e) {
-    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2025") {
-      return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+    if (e instanceof Error && "code" in e) {
+      const code = (e as { code: string }).code;
+      if (code === "P2025") {
+        return NextResponse.json({ error: "Time log not found" }, { status: 404 });
+      }
+      if (code === "P2023") {
+        return invalidIdResponse();
+      }
     }
 
     throw e;

--- a/src/app/api/admin/timelogs/route.ts
+++ b/src/app/api/admin/timelogs/route.ts
@@ -3,11 +3,12 @@ import * as z from "zod";
 
 import { verifyAdminApiKey } from "@/lib/admin-api-auth";
 import { adminCreateTimeLog, adminGetAllTimeLogs } from "@/lib/data/timelog-dto";
+import { objectIdSchema } from "@/lib/objectid";
 
 const statusSchema = z.enum(["CURRENTLY_IN", "DONE", "LOCKED"]);
 
 const createSchema = z.object({
-  userId: z.string().trim().nonempty(),
+  userId: objectIdSchema,
   status: statusSchema,
   inTime: z.iso.datetime().transform(v => new Date(v)),
   outTime: z.iso.datetime().transform(v => new Date(v)).optional(),
@@ -21,7 +22,7 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
 
   const querySchema = z.object({
-    userId: z.string().trim().nonempty().optional(),
+    userId: objectIdSchema.optional(),
     status: statusSchema.optional(),
     startTime: z.iso.datetime().transform(v => new Date(v)).optional(),
     endTime: z.iso.datetime().transform(v => new Date(v)).optional(),

--- a/src/app/api/admin/timelogs/route.ts
+++ b/src/app/api/admin/timelogs/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as z from "zod";
+
+import { verifyAdminApiKey } from "@/lib/admin-api-auth";
+import { adminCreateTimeLog, adminGetAllTimeLogs } from "@/lib/data/timelog-dto";
+
+const statusSchema = z.enum(["CURRENTLY_IN", "DONE", "LOCKED"]);
+
+const createSchema = z.object({
+  userId: z.string().trim().nonempty(),
+  status: statusSchema,
+  inTime: z.iso.datetime().transform(v => new Date(v)),
+  outTime: z.iso.datetime().transform(v => new Date(v)).optional(),
+  notes: z.string().trim().nonempty().optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { searchParams } = req.nextUrl;
+
+  const querySchema = z.object({
+    userId: z.string().trim().nonempty().optional(),
+    status: statusSchema.optional(),
+    startTime: z.iso.datetime().transform(v => new Date(v)).optional(),
+    endTime: z.iso.datetime().transform(v => new Date(v)).optional(),
+  });
+
+  try {
+    const parsed = querySchema.parse({
+      userId: searchParams.get("userId") || undefined,
+      status: searchParams.get("status") || undefined,
+      startTime: searchParams.get("startTime") || undefined,
+      endTime: searchParams.get("endTime") || undefined,
+    });
+
+    const timeLogs = await adminGetAllTimeLogs(parsed);
+
+    return NextResponse.json({ data: timeLogs });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json({ error: "Validation failed", issues: e.issues }, { status: 400 });
+    }
+
+    throw e;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const parsed = createSchema.parse(body);
+    const timeLog = await adminCreateTimeLog(parsed);
+
+    return NextResponse.json({ data: timeLog }, { status: 201 });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json({ error: "Validation failed", issues: e.issues }, { status: 400 });
+    }
+
+    if (e instanceof Error && (
+      e.message === "Out time is required for DONE or LOCKED status"
+      || e.message === "Out time must be after in time"
+    )) {
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    }
+
+    throw e;
+  }
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -3,6 +3,7 @@ import * as z from "zod";
 
 import { verifyAdminApiKey } from "@/lib/admin-api-auth";
 import { adminDeleteUser, adminGetUser, adminUpdateUser } from "@/lib/data/user-dto";
+import { objectIdSchema } from "@/lib/objectid";
 
 const updateSchema = z.object({
   email: z.email().toLowerCase(),
@@ -11,11 +12,19 @@ const updateSchema = z.object({
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+function invalidIdResponse() {
+  return NextResponse.json({ error: "Invalid id format" }, { status: 400 });
+}
+
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const authError = verifyAdminApiKey(req);
   if (authError) return authError;
 
   const { id } = await params;
+  if (!objectIdSchema.safeParse(id).success) {
+    return invalidIdResponse();
+  }
+
   const user = await adminGetUser(id);
 
   if (!user) {
@@ -30,6 +39,9 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
   if (authError) return authError;
 
   const { id } = await params;
+  if (!objectIdSchema.safeParse(id).success) {
+    return invalidIdResponse();
+  }
 
   let body: unknown;
   try {
@@ -56,6 +68,9 @@ export async function PUT(req: NextRequest, { params }: RouteParams) {
       if (code === "P2002") {
         return NextResponse.json({ error: "A user with this email already exists" }, { status: 409 });
       }
+      if (code === "P2023") {
+        return invalidIdResponse();
+      }
     }
 
     throw e;
@@ -67,13 +82,22 @@ export async function DELETE(req: NextRequest, { params }: RouteParams) {
   if (authError) return authError;
 
   const { id } = await params;
+  if (!objectIdSchema.safeParse(id).success) {
+    return invalidIdResponse();
+  }
 
   try {
     const user = await adminDeleteUser(id);
     return NextResponse.json({ data: user });
   } catch (e) {
-    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2025") {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    if (e instanceof Error && "code" in e) {
+      const code = (e as { code: string }).code;
+      if (code === "P2025") {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+      }
+      if (code === "P2023") {
+        return invalidIdResponse();
+      }
     }
 
     throw e;

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as z from "zod";
+
+import { verifyAdminApiKey } from "@/lib/admin-api-auth";
+import { adminDeleteUser, adminGetUser, adminUpdateUser } from "@/lib/data/user-dto";
+
+const updateSchema = z.object({
+  email: z.email().toLowerCase(),
+  name: z.string().trim().nonempty(),
+});
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { id } = await params;
+  const user = await adminGetUser(id);
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ data: user });
+}
+
+export async function PUT(req: NextRequest, { params }: RouteParams) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const parsed = updateSchema.parse(body);
+    const user = await adminUpdateUser(id, parsed);
+
+    return NextResponse.json({ data: user });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json({ error: "Validation failed", issues: e.issues }, { status: 400 });
+    }
+
+    if (e instanceof Error && "code" in e) {
+      const code = (e as { code: string }).code;
+      if (code === "P2025") {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+      }
+      if (code === "P2002") {
+        return NextResponse.json({ error: "A user with this email already exists" }, { status: 409 });
+      }
+    }
+
+    throw e;
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const { id } = await params;
+
+  try {
+    const user = await adminDeleteUser(id);
+    return NextResponse.json({ data: user });
+  } catch (e) {
+    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2025") {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    throw e;
+  }
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as z from "zod";
+
+import { verifyAdminApiKey } from "@/lib/admin-api-auth";
+import { adminCreateUser, adminGetAllUsers } from "@/lib/data/user-dto";
+
+const createSchema = z.object({
+  email: z.email().toLowerCase(),
+  name: z.string().trim().nonempty(),
+});
+
+export async function GET(req: NextRequest) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  const email = req.nextUrl.searchParams.get("email") || undefined;
+
+  const users = await adminGetAllUsers({ email });
+
+  return NextResponse.json({ data: users });
+}
+
+export async function POST(req: NextRequest) {
+  const authError = verifyAdminApiKey(req);
+  if (authError) return authError;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const parsed = createSchema.parse(body);
+    const user = await adminCreateUser(parsed);
+
+    return NextResponse.json({ data: user }, { status: 201 });
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return NextResponse.json({ error: "Validation failed", issues: e.issues }, { status: 400 });
+    }
+
+    if (e instanceof Error && "code" in e && (e as { code: string }).code === "P2002") {
+      return NextResponse.json({ error: "A user with this email already exists" }, { status: 409 });
+    }
+
+    throw e;
+  }
+}

--- a/src/lib/admin-api-auth.ts
+++ b/src/lib/admin-api-auth.ts
@@ -1,0 +1,30 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "crypto";
+
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+
+  return timingSafeEqual(bufA, bufB);
+}
+
+export function verifyAdminApiKey(req: NextRequest): NextResponse | null {
+  const adminApiKey = process.env.ADMIN_API_KEY;
+  if (!adminApiKey) {
+    return NextResponse.json({ error: "Admin API is not configured" }, { status: 503 });
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : undefined;
+
+  if (!token || !safeCompare(token, adminApiKey)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/src/lib/data/timelog-dto.ts
+++ b/src/lib/data/timelog-dto.ts
@@ -610,8 +610,8 @@ export async function adminUpdateTimeLog(timeLogId: string, data: {
       userId: data.userId,
       status,
       inTime: data.inTime,
-      outTime: data.outTime,
-      notes: data.notes,
+      outTime: data.outTime ?? null,
+      notes: data.notes ?? null,
     },
   });
 

--- a/src/lib/data/timelog-dto.ts
+++ b/src/lib/data/timelog-dto.ts
@@ -491,4 +491,137 @@ export async function deleteTimeLogs(timeLogIds: string[]) {
   });
 
   return payload;
-} 
+}
+
+// The functions below are for the API-key authenticated Admin API
+// (see src/lib/admin-api-auth.ts). They intentionally skip the NextAuth
+// session/role checks above, since the route handlers calling them already
+// gate access via the admin API key.
+
+function toPrismaTimeLogStatus(status: TimeLogDTO["status"]): "CurrentlyIn" | "Done" | "Locked" {
+  if (status === "CURRENTLY_IN") return "CurrentlyIn";
+  if (status === "DONE") return "Done";
+  return "Locked";
+}
+
+export type AdminGetAllTimeLogsOptions = {
+  userId: string;
+  startTime: Date;
+  endTime: Date;
+  status: TimeLogDTO["status"];
+}
+
+export async function adminGetAllTimeLogs(opts?: Partial<AdminGetAllTimeLogsOptions>): Promise<TimeLogDTO[]> {
+  const { userId, startTime, endTime, status } = opts || {};
+
+  const where: Prisma.TimeLogWhereInput = {};
+
+  if (userId) {
+    where.userId = userId;
+  }
+
+  if (startTime || endTime) {
+    where.OR = [
+      {
+        inTime: {
+          gte: startTime,
+          lt: endTime,
+        },
+      },
+      {
+        outTime: {
+          gte: startTime,
+          lt: endTime,
+        },
+      },
+    ];
+  }
+
+  if (status) {
+    where.status = toPrismaTimeLogStatus(status);
+  }
+
+  const timeLogs = await prisma.timeLog.findMany({
+    where,
+    orderBy: { inTime: "desc" },
+  });
+
+  return timeLogs.map(prismaTimeLogToDTO);
+}
+
+export async function adminGetTimeLog(id: string): Promise<TimeLogDTO | null> {
+  const timeLog = await prisma.timeLog.findUnique({
+    where: { id },
+  });
+
+  return timeLog ? prismaTimeLogToDTO(timeLog) : null;
+}
+
+export async function adminCreateTimeLog(data: {
+  userId: string;
+  status: TimeLogDTO["status"];
+  inTime: Date;
+  outTime?: Date;
+  notes?: string | null;
+}): Promise<TimeLogDTO> {
+  const status = toPrismaTimeLogStatus(data.status);
+
+  if (data.status !== "CURRENTLY_IN" && !data.outTime) {
+    throw new Error("Out time is required for DONE or LOCKED status");
+  }
+
+  if (data.outTime && data.outTime <= data.inTime) {
+    throw new Error("Out time must be after in time");
+  }
+
+  const result = await prisma.timeLog.create({
+    data: {
+      userId: data.userId,
+      status,
+      inTime: data.inTime,
+      outTime: data.outTime,
+      notes: data.notes,
+    },
+  });
+
+  return prismaTimeLogToDTO(result);
+}
+
+export async function adminUpdateTimeLog(timeLogId: string, data: {
+  userId: string;
+  status: TimeLogDTO["status"];
+  inTime: Date;
+  outTime?: Date;
+  notes?: string | null;
+}): Promise<TimeLogDTO> {
+  const status = toPrismaTimeLogStatus(data.status);
+
+  if (data.status !== "CURRENTLY_IN" && !data.outTime) {
+    throw new Error("Out time is required for DONE or LOCKED status");
+  }
+
+  if (data.outTime && data.outTime <= data.inTime) {
+    throw new Error("Out time must be after in time");
+  }
+
+  const result = await prisma.timeLog.update({
+    where: { id: timeLogId },
+    data: {
+      userId: data.userId,
+      status,
+      inTime: data.inTime,
+      outTime: data.outTime,
+      notes: data.notes,
+    },
+  });
+
+  return prismaTimeLogToDTO(result);
+}
+
+export async function adminDeleteTimeLog(timeLogId: string): Promise<TimeLogDTO> {
+  const timeLog = await prisma.timeLog.delete({
+    where: { id: timeLogId },
+  });
+
+  return prismaTimeLogToDTO(timeLog);
+}

--- a/src/lib/data/user-dto.ts
+++ b/src/lib/data/user-dto.ts
@@ -167,3 +167,61 @@ export async function deleteUsers(ids: string[]) {
 
   return payload;
 }
+
+// The functions below are for the API-key authenticated Admin API
+// (see src/lib/admin-api-auth.ts). They intentionally skip the NextAuth
+// session/role checks above, since the route handlers calling them already
+// gate access via the admin API key.
+
+export async function adminGetAllUsers(opts?: { email?: string }): Promise<UserDTO[]> {
+  const users = await prisma.user.findMany({
+    where: opts?.email ? { email: { contains: opts.email, mode: "insensitive" } } : undefined,
+  });
+
+  return users.map(prismaUserToDTO);
+}
+
+export async function adminGetUser(id: string): Promise<UserDTO | null> {
+  const user = await prisma.user.findUnique({
+    where: { id },
+  });
+
+  return user ? prismaUserToDTO(user) : null;
+}
+
+export async function adminCreateUser(data: {
+  email: string;
+  name: string;
+}): Promise<UserDTO> {
+  const user = await prisma.user.create({
+    data: {
+      email: data.email,
+      name: data.name,
+    },
+  });
+
+  return prismaUserToDTO(user);
+}
+
+export async function adminUpdateUser(id: string, data: {
+  email: string;
+  name: string;
+}): Promise<UserDTO> {
+  const user = await prisma.user.update({
+    where: { id },
+    data: {
+      email: data.email,
+      name: data.name,
+    },
+  });
+
+  return prismaUserToDTO(user);
+}
+
+export async function adminDeleteUser(id: string): Promise<UserDTO> {
+  const user = await prisma.user.delete({
+    where: { id },
+  });
+
+  return prismaUserToDTO(user);
+}

--- a/src/lib/objectid.ts
+++ b/src/lib/objectid.ts
@@ -1,0 +1,3 @@
+import * as z from "zod";
+
+export const objectIdSchema = z.string().regex(/^[0-9a-f]{24}$/i, "Invalid id format");


### PR DESCRIPTION
## Summary
- New REST endpoints under `/api/admin/users` and `/api/admin/timelogs` (GET/POST/PUT/DELETE) for external systems to manage users and time logs
- Authenticated via a static Bearer API key (`ADMIN_API_KEY` env var), checked with a constant-time comparison; returns 503 if unconfigured, 401 if invalid
- New admin-scoped data functions (`adminGet/Create/Update/DeleteUser`, `adminGet/Create/Update/DeleteTimeLog`) alongside existing session-based DTO functions, since the API key auth path has no NextAuth session
- OpenAPI 3.0 schema at `public/openapi/admin-api.json` documenting all endpoints, schemas, and the bearer auth scheme
- README section documenting usage

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] Manually verified against dev DB via `curl`:
  - [x] No/invalid token → 401; `ADMIN_API_KEY` unset → 503
  - [x] `POST/GET/PUT/DELETE /api/admin/users` and `/api/admin/users/{id}` — create, fetch, update, delete, 404 on missing id
  - [x] `POST/GET/PUT/DELETE /api/admin/timelogs` and `/api/admin/timelogs/{id}` — including validation error (DONE without outTime → 400) and query filters
- [x] Validated `public/openapi/admin-api.json` is well-formed JSON

Note: found a pre-existing gap where the dev MongoDB doesn't enforce the `email @unique` index (duplicate emails succeed) — predates this change and also affects the existing UI create flow; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)